### PR TITLE
Add license

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ let g:airline_theme='Kaninchenhaus'
 It requires [vim-colortemplate](https://github.com/lifepillar/vim-colortemplate) plugin.
 
 After installing the plugin, you can build the colorscheme by executing `make`.
+
+## License
+
+[Vim license](https://www.gnu.org/licenses/vim-license.txt)


### PR DESCRIPTION
Add license declaration in README.md.
The script file `colors/Kaninchenhaus.vim` have said that the Vim license is applied to it but it was missing in the README.
